### PR TITLE
Add documentation for caip10-links

### DIFF
--- a/docs/build/reading.md
+++ b/docs/build/reading.md
@@ -4,7 +4,7 @@ Use the [`idx.get()`](../reference/idx.md#get) method to query a [record](../lea
 
 ## **Using default aliases**
 
-Pass an alias from [default definitions](../guides/definitions/default.md), and the [DID](../learn/glossary.md#did) or [Blockchain Account ID](../learn/glossary.md##caip-10-account-id) that you wish to query.
+Pass an alias from [default definitions](../guides/definitions/default.md), and the [DID](../learn/glossary.md#did) or [Blockchain Account ID](../learn/glossary.md#caip-10-account-id) that you wish to query.
 
 For example if you want to query IDX data from the ethereum account `0xab16a96d359ec26a11e2c2b3d8f8b8942d5bfcdb` on mainnet you can simply use the string `0xab16a96d359ec26a11e2c2b3d8f8b8942d5bfcdb@eip155:1`.
 

--- a/docs/build/reading.md
+++ b/docs/build/reading.md
@@ -4,20 +4,22 @@ Use the [`idx.get()`](../reference/idx.md#get) method to query a [record](../lea
 
 ## **Using default aliases**
 
-Pass an alias from [default definitions](../guides/definitions/default.md) and the DID that you wish to query.
+Pass an alias from [default definitions](../guides/definitions/default.md), and the [DID](../learn/glossary.md#did) or [Blockchain Account ID](../learn/glossary.md##caip-10-account-id) that you wish to query.
+
+For example if you want to query IDX data from the ethereum account `0xab16a96d359ec26a11e2c2b3d8f8b8942d5bfcdb` on mainnet you can simply use the string `0xab16a96d359ec26a11e2c2b3d8f8b8942d5bfcdb@eip155:1`.
 
 ```js
-await idx.get('basicProfile', '<DID>')
+await idx.get('basicProfile', '<DID-or-caip10-id>')
 ```
 
 [:octicons-file-code-16: API reference](../reference/idx.md#get)
 
 ## **Using your aliases**
 
-Pass as alias from your `aliases` object and the DID that you wish to query.
+Pass as alias from your `aliases` object, and the [DID](../learn/glossary.md#did) or [Blockchain Account ID](../learn/glossary.md##caip-10-account-id) that you wish to query.
 
 ```js
-await idx.get('myAlias', '<DID>')
+await idx.get('myAlias', '<DID-or-caip10-id>')
 ```
 
 [:octicons-file-code-16: API reference](../reference/idx.md#get)

--- a/docs/build/reading.md
+++ b/docs/build/reading.md
@@ -16,7 +16,7 @@ await idx.get('basicProfile', '<DID-or-caip10-id>')
 
 ## **Using your aliases**
 
-Pass as alias from your `aliases` object, and the [DID](../learn/glossary.md#did) or [Blockchain Account ID](../learn/glossary.md##caip-10-account-id) that you wish to query.
+Pass as alias from your `aliases` object, and the [DID](../learn/glossary.md#did) or [Blockchain Account ID](../learn/glossary.md#caip-10-account-id) that you wish to query.
 
 ```js
 await idx.get('myAlias', '<DID-or-caip10-id>')

--- a/docs/learn/glossary.md
+++ b/docs/learn/glossary.md
@@ -209,6 +209,27 @@ DIDs is the [W3C standard](https://www.w3.org/TR/did-core/) for gloablly unique 
     ```
     did:3:bafy124123123123123123123123123123
     ```
+    
+
+### **CAIP-10 Account ID**
+
+[CAIP-10 Account IDs](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md) is a blockchain agnostic way to describe an account on any blockchain. This may be an externally owned key-pair account, or a smart contract account. IDX uses CAIP-10s as a way to lookup the DID of a user using a `caip10-link` doctype in Ceramic. Learn more in the [Ceramic documentation](https://developers.ceramic.network).
+
+=== "Example CAIP-10 Account IDs"
+
+    ```
+    # Ethereum mainnet
+    0xab16a96d359ec26a11e2c2b3d8f8b8942d5bfcdb@eip155:1
+
+    # Bitcoin mainnet
+    128Lkh3S7CkDTBZ8W7BbpsN3YYizJMp8p6@bip122:000000000019d6689c085ae165831e93
+
+    # Cosmos Hub
+    cosmos1t2uflqwqe0fsj0shcfkrvpukewcw40yjj6hdc0@cosmos:cosmoshub-3
+
+    # Kusama network
+    5hmuyxw9xdgbpptgypokw4thfyoe3ryenebr381z9iaegmfy@polkadot:b0a8d493285c2df73290dfb7e61f870f
+    ```
 
 ### **Ceramic**
 

--- a/docs/reference/idx.md
+++ b/docs/reference/idx.md
@@ -45,7 +45,7 @@ Returns whether a [record](../learn/glossary.md#record) exists in the [index](..
 
 ### **.get()**
 
-Returns a [record](../learn/glossary.md#record) in the [index](../learn/glossary.md#index) for a given [DID](../learn/glossary.md#did).
+Returns a [record](../learn/glossary.md#record) in the [index](../learn/glossary.md#index) for a given [DID](../learn/glossary.md#did) or [Blockchain Account ID](../learn/glossary.md##caip-10-account-id) .
 
 **Arguments:**
 

--- a/docs/reference/idx.md
+++ b/docs/reference/idx.md
@@ -45,7 +45,7 @@ Returns whether a [record](../learn/glossary.md#record) exists in the [index](..
 
 ### **.get()**
 
-Returns a [record](../learn/glossary.md#record) in the [index](../learn/glossary.md#index) for a given [DID](../learn/glossary.md#did) or [Blockchain Account ID](../learn/glossary.md##caip-10-account-id) .
+Returns a [record](../learn/glossary.md#record) in the [index](../learn/glossary.md#index) for a given [DID](../learn/glossary.md#did) or [Blockchain Account ID](../learn/glossary.md#caip-10-account-id) .
 
 **Arguments:**
 


### PR DESCRIPTION
Adds some information about how to use CAIP-10 account ids with IDX.

Let me know if I missed anything!