### PR TITLE
Update npm requirement to v7+

### DIFF
--- a/docs/build/quick-start.md
+++ b/docs/build/quick-start.md
@@ -10,7 +10,7 @@ Get started exploring what's possible with IDX using the [IDX CLI](../reference/
 
 ## **Prerequisites**
 
-The IDX CLI requires [Node.js](https://nodejs.org/en/) v14+ and npm v6+ (usually installed with Node.js). Make sure to have both installed.
+The IDX CLI requires [Node.js](https://nodejs.org/en/) v14+ and npm v7+ (usually installed with Node.js). Make sure to have both installed.
 
 On Linux you will also need the `libsecret` library to be installed, as [instructed here](https://github.com/atom/node-keytar#on-linux).
 

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-The IDX CLI requires [Node.js](https://nodejs.org/en/) v14 and npm v6 (usually installed with Node.js). Make sure to have both installed.
+The IDX CLI requires [Node.js](https://nodejs.org/en/) v14+ and npm v7+ (usually installed with Node.js). Make sure to have both installed.
 
 On Linux you will also need the `libsecret` library to be installed, as [instructed here](https://github.com/atom/node-keytar#on-linux).
 


### PR DESCRIPTION
npm v6 installation of a ceramic node from packages on a linux system fails due to an ipfs-unixfs dependency on npm 7+

The errors:

```
npm WARN notsup Unsupported engine for ipfs-unixfs@4.0.3: wanted: {"node":">=14.0.0","npm":">=7.0.0"} (current: {"node":"14.17.1","npm":"6.14.13"})
npm WARN notsup Not compatible with your version of node/npm: ipfs-unixfs@4.0.3
npm WARN notsup Unsupported engine for ipfs-unixfs-exporter@5.0.3: wanted: {"node":">=14.0.0","npm":">=7.0.0"} (current: {"node":"14.17.1","npm":"6.14.13"})
npm WARN notsup Not compatible with your version of node/npm: ipfs-unixfs-exporter@5.0.3
npm WARN notsup Unsupported engine for ipfs-unixfs-importer@7.0.3: wanted: {"node":">=14.0.0","npm":">=7.0.0"} (current: {"node":"14.17.1","npm":"6.14.13"})
npm WARN notsup Not compatible with your version of node/npm: ipfs-unixfs-importer@7.0.3
```

System info:

```
$ uname -a
Linux home 4.19.0-17-amd64 #1 SMP Debian 4.19.194-3 (2021-07-18) x86_64 GNU/Linux
```